### PR TITLE
Enable export when a valid tick selection exists

### DIFF
--- a/src/lineOfSight.ts
+++ b/src/lineOfSight.ts
@@ -221,7 +221,10 @@ export class LineOfSight {
       isReplaying: !!this.replayAuto,
       hasReplay: !!this.replay && this.replayTick !== null && !!this.replay[this.replayTick],
       replayLength: this.replay?.length ?? null,
-      canSaveReplay: !this.replayAuto && this.tape.length > 0 && this.tape.length <= 32,
+      canSaveReplay: !this.replayAuto && this.tape.length > 0 && (
+        this.tape.length <= 32 ||
+        (this.tapeSelectionRange?.length === 2 && this.tapeSelectionRange[1] - this.tapeSelectionRange[0] <= 32)
+      ),
       replayTick: this.replayTick ?? 0
     }
     // check if any UI state has changed


### PR DESCRIPTION
Copy Replay URL and Export Video buttons were greyed out whenever the ticker tape exceeded 32 ticks, even if a sub-32-tick selection had been made in the ticker.

Both buttons already call `getReplayData()` which correctly uses tapeSelectionRange when set, but `canSaveReplay` wasn't accounting for it. This adds the selection length check so the buttons re-enable when a valid selection (≤ 32 ticks) is active.