### PR TITLE
Fix replay URL cooldown loss on mid-simulation selections

### DIFF
--- a/src/lineOfSight.ts
+++ b/src/lineOfSight.ts
@@ -62,6 +62,8 @@ export class LineOfSight {
   // tape for mobs
   tape: TapeEntry[] = [];
   cooldownTape: number[][] = [];
+  extraTape: MobExtra[][] = []; // manticore charge state only; null for other mob types
+  manticoreTicksRemainingTape: number[][] = []; // manticore orb sequence only; 0 for other mob types
   playerTape: Coordinates[] = [];
   tapeSelectionRange: number[] | null = null; // tape selection, [start, end. TODO remove
   initialMobCooldowns: number[] | null = null;
@@ -427,10 +429,20 @@ export class LineOfSight {
       return;
     }
     this.hasLoadedSpawns = true;
-    const { mobs: decodedMobs, isFromWaveStart, isMantiMayhem3, playerCoordinates, isReplay } = decodeURL(new URL(window.location.toString()));
+    const { mobs: decodedMobs, isFromWaveStart, isMantiMayhem3, playerCoordinates, isReplay, mobTicksRemaining } = decodeURL(new URL(window.location.toString()));
+    // sortMobs() reorders the array, so pair each mob with its decoded ticksRemaining
+    // by object identity (rather than index) before sorting.
+    const ticksRemainingByMob = new Map(decodedMobs.map((mob, i) => [mob, mobTicksRemaining[i] ?? 0]));
     this.mobs = decodedMobs;
     this.sortMobs();
     this.initialMobCooldowns = this.mobs.map(m => m[5]);
+    this.manticoreTicksRemaining = {};
+    this.mobs.forEach((mob, i) => {
+      const ticks = ticksRemainingByMob.get(mob) ?? 0;
+      if (mob[2] === MANTICORE && ticks > 0) {
+        this.manticoreTicksRemaining[i] = ticks;
+      }
+    });
     this.setFromWaveStart(isFromWaveStart);
     this.setMantimayhem3(isMantiMayhem3);
     if (!playerCoordinates) {
@@ -502,6 +514,13 @@ export class LineOfSight {
     // movement/attacks run. The actual state at the START of the selection (i.e.
     // before tick lowerBound runs) is whatever was recorded at the end of the
     // previous tick - or the mob's original spawn state, if lowerBound is 0.
+    const mobCooldowns = this.getSnapshotAtTick(this.cooldownTape, lowerBound, this.mobs.map(() => 0));
+    const mobTicksRemaining = this.getSnapshotAtTick(this.manticoreTicksRemainingTape, lowerBound, this.mobs.map(() => 0));
+    const mobExtras = this.getSnapshotAtTick(
+      this.extraTape,
+      lowerBound,
+      this.mobs.map((mob) => mob[2] === MANTICORE && mob[7] !== undefined ? mob[7] : mob[6])
+    );
     const mobSpecs = this.mobs.map((mob, mobIdx) => {
       let x = mob[3];
       let y = mob[4];
@@ -510,26 +529,20 @@ export class LineOfSight {
         x = (prevTick >> 16) & 0xff;
         y = (prevTick >> 24) & 0xff;
       }
-      return [
-        x,
-        y,
-        mob[2],
-        // Use original extra value for manticores if available
-        mob[2] === MANTICORE && mob[7] !== undefined ? mob[7] : mob[6],
-      ] as MobSpec;
+      return [x, y, mob[2], mobExtras[mobIdx]] as MobSpec;
     });
-    const mobCooldowns = this.getCooldownsAtTick(lowerBound);
-    return { playerPositions, mobSpecs, mobCooldowns };
+    return { playerPositions, mobSpecs, mobCooldowns, mobTicksRemaining };
   }
 
-  private getCooldownsAtTick(tickIndex: number): number[] {
-    if (tickIndex === 0 || this.cooldownTape.length === 0) {
-      return this.mobs.map(() => 0);
+  // Looks up the per-mob state recorded at the end of the tick before tickIndex,
+  // i.e. the state at the START of tickIndex (mobSpecs/mobCooldowns/mobTicksRemaining
+  // are all anchored to this same instant). Falls back when there's no tape yet.
+  private getSnapshotAtTick<T>(snapshotTape: T[][], tickIndex: number, fallback: T[]): T[] {
+    if (tickIndex === 0 || snapshotTape.length === 0) {
+      return fallback;
     }
-    // Same reasoning as mobSpecs above: the state at the START of tickIndex
-    // is what was recorded at the end of the previous tick.
-    const snapshotIndex = Math.min(tickIndex - 1, this.cooldownTape.length - 1);
-    return [...this.cooldownTape[snapshotIndex]];
+    const snapshotIndex = Math.min(tickIndex - 1, snapshotTape.length - 1);
+    return [...snapshotTape[snapshotIndex]];
   }
 
   public copyReplayURL() {
@@ -562,12 +575,12 @@ export class LineOfSight {
 
   private removeMob(index: number) {
     this.mobs.splice(index, 1);
-    this.tape = this.tape.map((entries) => {
-      return entries.filter((_mobData, i) => i !== index);
-    });
-    this.cooldownTape = this.cooldownTape.map((entries) => {
-      return entries.filter((_cd, i) => i !== index);
-    });
+    const removeIndex = <T,>(perTickEntries: T[][]) =>
+      perTickEntries.map((entries) => entries.filter((_entry, i) => i !== index));
+    this.tape = removeIndex(this.tape);
+    this.cooldownTape = removeIndex(this.cooldownTape);
+    this.extraTape = removeIndex(this.extraTape);
+    this.manticoreTicksRemainingTape = removeIndex(this.manticoreTicksRemainingTape);
   }
 
   private hasLOS(
@@ -984,6 +997,8 @@ export class LineOfSight {
       this.playerTape.push([this.selected[0], this.selected[1]]);
       this.tape.push(line);
       this.cooldownTape.push(this.mobs.map(m => m[5]));
+      this.extraTape.push(this.mobs.map(m => m[6]));
+      this.manticoreTicksRemainingTape.push(this.mobs.map((_m, idx) => this.manticoreTicksRemaining[idx] ?? 0));
     }
     this.tickCount++;
     if (draw) {
@@ -1045,6 +1060,8 @@ export class LineOfSight {
     this.manticoreTicksRemaining = {};
     this.tape = [];
     this.cooldownTape = [];
+    this.extraTape = [];
+    this.manticoreTicksRemainingTape = [];
     this.playerTape = [];
     this.tapeSelectionRange = null;
     this.tickCount = 0;

--- a/src/lineOfSight.ts
+++ b/src/lineOfSight.ts
@@ -61,8 +61,10 @@ export class LineOfSight {
   mobs: Mob[] = [];
   // tape for mobs
   tape: TapeEntry[] = [];
+  cooldownTape: number[][] = [];
   playerTape: Coordinates[] = [];
   tapeSelectionRange: number[] | null = null; // tape selection, [start, end. TODO remove
+  initialMobCooldowns: number[] | null = null;
 
   tickCount = 0;
 
@@ -221,7 +223,10 @@ export class LineOfSight {
       isReplaying: !!this.replayAuto,
       hasReplay: !!this.replay && this.replayTick !== null && !!this.replay[this.replayTick],
       replayLength: this.replay?.length ?? null,
-      canSaveReplay: !this.replayAuto && this.tape.length > 0 && this.tape.length <= 32,
+      canSaveReplay: !this.replayAuto && this.tape.length > 0 && (
+        this.tape.length <= 32 ||
+        (this.tapeSelectionRange?.length === 2 && this.tapeSelectionRange[1] - this.tapeSelectionRange[0] <= 32)
+      ),
       replayTick: this.replayTick ?? 0
     }
     // check if any UI state has changed
@@ -425,6 +430,7 @@ export class LineOfSight {
     const { mobs: decodedMobs, isFromWaveStart, isMantiMayhem3, playerCoordinates, isReplay } = decodeURL(new URL(window.location.toString()));
     this.mobs = decodedMobs;
     this.sortMobs();
+    this.initialMobCooldowns = this.mobs.map(m => m[5]);
     this.setFromWaveStart(isFromWaveStart);
     this.setMantimayhem3(isMantiMayhem3);
     if (!playerCoordinates) {
@@ -490,23 +496,40 @@ export class LineOfSight {
       lowerBound = 0;
       upperBoundInclusive = Math.min(this.tape.length, MAX_EXPORT_LENGTH);
     }
-    var mobTicks = this.tape.slice(lowerBound, upperBoundInclusive);
     var playerPositions = this.playerTape.slice(lowerBound, upperBoundInclusive);
 
-    // get the mob positions/specs at the start of the selection
-    const mobSpecs = mobTicks[0].map(
-      (value, mobIdx) =>
-        [
-          (value >> 16) & 0xff,
-          (value >> 24) & 0xff,
-          this.mobs[mobIdx][2],
-          // Use original extra value for manticores if available
-          this.mobs[mobIdx][2] === MANTICORE && this.mobs[mobIdx][7] !== undefined
-            ? this.mobs[mobIdx][7]
-            : this.mobs[mobIdx][6],
-        ] as MobSpec
-    );
-    return { playerPositions, mobSpecs };
+    // Tick lowerBound's tape/cooldownTape entries are recorded AFTER that tick's
+    // movement/attacks run. The actual state at the START of the selection (i.e.
+    // before tick lowerBound runs) is whatever was recorded at the end of the
+    // previous tick - or the mob's original spawn state, if lowerBound is 0.
+    const mobSpecs = this.mobs.map((mob, mobIdx) => {
+      let x = mob[3];
+      let y = mob[4];
+      if (lowerBound > 0) {
+        const prevTick = this.tape[lowerBound - 1][mobIdx];
+        x = (prevTick >> 16) & 0xff;
+        y = (prevTick >> 24) & 0xff;
+      }
+      return [
+        x,
+        y,
+        mob[2],
+        // Use original extra value for manticores if available
+        mob[2] === MANTICORE && mob[7] !== undefined ? mob[7] : mob[6],
+      ] as MobSpec;
+    });
+    const mobCooldowns = this.getCooldownsAtTick(lowerBound);
+    return { playerPositions, mobSpecs, mobCooldowns };
+  }
+
+  private getCooldownsAtTick(tickIndex: number): number[] {
+    if (tickIndex === 0 || this.cooldownTape.length === 0) {
+      return this.mobs.map(() => 0);
+    }
+    // Same reasoning as mobSpecs above: the state at the START of tickIndex
+    // is what was recorded at the end of the previous tick.
+    const snapshotIndex = Math.min(tickIndex - 1, this.cooldownTape.length - 1);
+    return [...this.cooldownTape[snapshotIndex]];
   }
 
   public copyReplayURL() {
@@ -541,6 +564,9 @@ export class LineOfSight {
     this.mobs.splice(index, 1);
     this.tape = this.tape.map((entries) => {
       return entries.filter((_mobData, i) => i !== index);
+    });
+    this.cooldownTape = this.cooldownTape.map((entries) => {
+      return entries.filter((_cd, i) => i !== index);
     });
   }
 
@@ -957,6 +983,7 @@ export class LineOfSight {
       // Record this tick's player position and mob actions to history
       this.playerTape.push([this.selected[0], this.selected[1]]);
       this.tape.push(line);
+      this.cooldownTape.push(this.mobs.map(m => m[5]));
     }
     this.tickCount++;
     if (draw) {
@@ -1004,7 +1031,7 @@ export class LineOfSight {
     for (var i = 0; i < this.mobs.length; i++) {
       this.mobs[i][0] = this.mobs[i][3];
       this.mobs[i][1] = this.mobs[i][4];
-      this.mobs[i][5] = 0;
+      this.mobs[i][5] = this.initialMobCooldowns?.[i] ?? 0;
 
       // Reset manticores to their original state
       if (this.mobs[i][2] === MANTICORE) {
@@ -1017,6 +1044,7 @@ export class LineOfSight {
     }
     this.manticoreTicksRemaining = {};
     this.tape = [];
+    this.cooldownTape = [];
     this.playerTape = [];
     this.tapeSelectionRange = null;
     this.tickCount = 0;

--- a/src/test/url.test.ts
+++ b/src/test/url.test.ts
@@ -177,6 +177,90 @@ describe("url tests", () => {
     });
   });
 
+  describe("cooldown encoding tests", () => {
+    test("replay url with no cooldowns omits _cd", () => {
+      const replay: ReplayData = {
+        mobSpecs: [createMob(0, 0, 1)],
+        playerPositions: [[0, 0]],
+        mobCooldowns: [0],
+      };
+      expect(getReplayURL(replay)).toBe("http://localhost:3000/?00001.#0");
+    });
+
+    test("replay url with non-zero cooldowns appends _cd", () => {
+      const replay: ReplayData = {
+        mobSpecs: [createMob(0, 0, 1), createMob(5, 5, 2)],
+        playerPositions: [[0, 0]],
+        mobCooldowns: [3, 0],
+      };
+      expect(getReplayURL(replay)).toBe("http://localhost:3000/?00001.05052.#0_cd:3,0");
+    });
+
+    test("_cd with _ws", () => {
+      const replay: ReplayData = {
+        mobSpecs: [createMob(0, 0, 1)],
+        playerPositions: [[0, 0]],
+        mobCooldowns: [5],
+      };
+      expect(getReplayURL(replay, true)).toBe("http://localhost:3000/?00001.#0_ws_cd:5");
+    });
+
+    test("_cd with _mm3", () => {
+      const replay: ReplayData = {
+        mobSpecs: [createMob(0, 0, 1)],
+        playerPositions: [[0, 0]],
+        mobCooldowns: [2],
+      };
+      expect(getReplayURL(replay, false, true)).toBe("http://localhost:3000/?00001.#0_mm3_cd:2");
+    });
+
+    test("_cd with _ws and _mm3", () => {
+      const replay: ReplayData = {
+        mobSpecs: [createMob(0, 0, 1)],
+        playerPositions: [[0, 0]],
+        mobCooldowns: [7],
+      };
+      expect(getReplayURL(replay, true, true)).toBe("http://localhost:3000/?00001.#0_ws_mm3_cd:7");
+    });
+  });
+
+  describe("cooldown decoding tests", () => {
+    test("decoding url with _cd sets mob cooldowns", () => {
+      const result = decodeURL(new URL("http://localhost:5173/?11092.#2311.2055_cd:3,0"));
+      expect(result.mobs[0][5]).toBe(3);
+    });
+
+    test("decoding url without _cd leaves cooldowns at 0", () => {
+      const result = decodeURL(new URL("http://localhost:5173/?11092.#2311.2055"));
+      expect(result.mobs[0][5]).toBe(0);
+    });
+
+    test("decoding url with _ws and _cd", () => {
+      const result = decodeURL(new URL("http://localhost:5173/?11092.#2311_ws_cd:5"));
+      expect(result.isFromWaveStart).toBe(true);
+      expect(result.mobs[0][5]).toBe(5);
+    });
+
+    test("decoding url with _mm3 and _cd", () => {
+      const result = decodeURL(new URL("http://localhost:5173/?11092.#2311_mm3_cd:4"));
+      expect(result.isMantiMayhem3).toBe(true);
+      expect(result.mobs[0][5]).toBe(4);
+    });
+
+    test("decoding url with _ws, _mm3, and _cd", () => {
+      const result = decodeURL(new URL("http://localhost:5173/?11092.#2311_ws_mm3_cd:9"));
+      expect(result.isFromWaveStart).toBe(true);
+      expect(result.isMantiMayhem3).toBe(true);
+      expect(result.mobs[0][5]).toBe(9);
+    });
+
+    test("_cd backwards compat: old urls without _cd still parse correctly", () => {
+      const result = decodeURL(new URL("http://localhost:5173/?11092.#2311.2055_ws"));
+      expect(result.mobs[0][5]).toBe(0);
+      expect(result.isFromWaveStart).toBe(true);
+    });
+  });
+
   describe("codec symmetry tests", () => {
     test("test 1", () => {
       const replay: ReplayData = {

--- a/src/test/url.test.ts
+++ b/src/test/url.test.ts
@@ -113,6 +113,7 @@ describe("url tests", () => {
         isFromWaveStart: false,
         isMantiMayhem3: false,
         isReplay: false,
+        mobTicksRemaining: [],
       });
     });
     
@@ -123,6 +124,7 @@ describe("url tests", () => {
         isFromWaveStart: false,
         isMantiMayhem3: false,
         isReplay: false,
+        mobTicksRemaining: [0],
       });
     });
 
@@ -133,6 +135,7 @@ describe("url tests", () => {
         isFromWaveStart: false,
         isMantiMayhem3: false,
         isReplay: false,
+        mobTicksRemaining: [0],
       });
     });
 
@@ -143,6 +146,7 @@ describe("url tests", () => {
         isFromWaveStart: false,
         isMantiMayhem3: false,
         isReplay: true,
+        mobTicksRemaining: [0],
       });
     });
 
@@ -153,6 +157,7 @@ describe("url tests", () => {
         isFromWaveStart: true,
         isMantiMayhem3: false,
         isReplay: true,
+        mobTicksRemaining: [0],
       });
     });
 
@@ -163,6 +168,7 @@ describe("url tests", () => {
         isFromWaveStart: false,
         isMantiMayhem3: true,
         isReplay: true,
+        mobTicksRemaining: [0],
       });
     });
 
@@ -173,6 +179,7 @@ describe("url tests", () => {
         isFromWaveStart: true,
         isMantiMayhem3: true,
         isReplay: true,
+        mobTicksRemaining: [0],
       });
     });
   });
@@ -258,6 +265,75 @@ describe("url tests", () => {
       const result = decodeURL(new URL("http://localhost:5173/?11092.#2311.2055_ws"));
       expect(result.mobs[0][5]).toBe(0);
       expect(result.isFromWaveStart).toBe(true);
+    });
+  });
+
+  describe("manticore orb sequence encoding tests", () => {
+    test("replay url with no ticks remaining and no cooldowns omits _cd", () => {
+      const replay: ReplayData = {
+        mobSpecs: [createMob(0, 0, 1)],
+        playerPositions: [[0, 0]],
+        mobCooldowns: [0],
+        mobTicksRemaining: [0],
+      };
+      expect(getReplayURL(replay)).toBe("http://localhost:3000/?00001.#0");
+    });
+
+    test("replay url with non-zero ticks remaining appends cooldown:ticks pair", () => {
+      const replay: ReplayData = {
+        mobSpecs: [createMob(0, 0, 1), createMob(5, 5, 2)],
+        playerPositions: [[0, 0]],
+        mobCooldowns: [10, 0],
+        mobTicksRemaining: [2, 0],
+      };
+      expect(getReplayURL(replay)).toBe("http://localhost:3000/?00001.05052.#0_cd:10:2,0");
+    });
+
+    test("ticks remaining alone (no other cooldowns) still emits _cd", () => {
+      const replay: ReplayData = {
+        mobSpecs: [createMob(0, 0, 1)],
+        playerPositions: [[0, 0]],
+        mobTicksRemaining: [1],
+      };
+      expect(getReplayURL(replay)).toBe("http://localhost:3000/?00001.#0_cd:0:1");
+    });
+
+    test("cooldown:ticks pair combined with _ws and _mm3", () => {
+      const replay: ReplayData = {
+        mobSpecs: [createMob(0, 0, 1)],
+        playerPositions: [[0, 0]],
+        mobCooldowns: [10],
+        mobTicksRemaining: [1],
+      };
+      expect(getReplayURL(replay, true, true)).toBe(
+        "http://localhost:3000/?00001.#0_ws_mm3_cd:10:1"
+      );
+    });
+  });
+
+  describe("manticore orb sequence decoding tests", () => {
+    test("decoding url with cooldown:ticks pair sets both cooldown and mobTicksRemaining", () => {
+      const result = decodeURL(new URL("http://localhost:5173/?11092.#2311.2055_cd:10:2"));
+      expect(result.mobs[0][5]).toBe(10);
+      expect(result.mobTicksRemaining).toEqual([2]);
+    });
+
+    test("decoding url with plain cooldown (no ticks suffix) leaves mobTicksRemaining at 0", () => {
+      const result = decodeURL(new URL("http://localhost:5173/?11092.#2311.2055_cd:10"));
+      expect(result.mobs[0][5]).toBe(10);
+      expect(result.mobTicksRemaining).toEqual([0]);
+    });
+
+    test("decoding url without _cd leaves mobTicksRemaining at 0", () => {
+      const result = decodeURL(new URL("http://localhost:5173/?11092.#2311.2055"));
+      expect(result.mobTicksRemaining).toEqual([0]);
+    });
+
+    test("decoding url with multiple cooldown:ticks pairs", () => {
+      const result = decodeURL(new URL("http://localhost:5173/?11092.11092.#2311.2055_cd:10:2,5"));
+      expect(result.mobs[0][5]).toBe(10);
+      expect(result.mobTicksRemaining).toEqual([2, 0]);
+      expect(result.mobs[1][5]).toBe(5);
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,4 +32,5 @@ export type ReplayData = {
   mobSpecs: MobSpec[];
   playerPositions: Coordinates[];
   mobCooldowns?: number[];
+  mobTicksRemaining?: number[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,4 +31,5 @@ export type TapeEntry = number[];
 export type ReplayData = {
   mobSpecs: MobSpec[];
   playerPositions: Coordinates[];
+  mobCooldowns?: number[];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,6 +138,7 @@ export type DecodeURLResult = {
   isMantiMayhem3: boolean;
   playerCoordinates: Coordinates[] | null;
   isReplay: boolean;
+  mobTicksRemaining: number[];
 }
 export function decodeURL(location: URL): DecodeURLResult {
   const mobSpawns = location.search
@@ -164,11 +165,18 @@ export function decodeURL(location: URL): DecodeURLResult {
   // Check flags
   const isFromWaveStart = hashParts?.includes("ws") || false;
   const isMantiMayhem3 = hashParts?.includes("mm3") || false;
+  const mobTicksRemaining = mobs.map(() => 0);
   const cdPart = hashParts?.find(p => p.startsWith("cd:"));
   if (cdPart) {
-    const cooldowns = cdPart.slice(3).split(",").map(Number);
-    for (var i = 0; i < mobs.length && i < cooldowns.length; i++) {
-      mobs[i][5] = cooldowns[i];
+    // Each entry is either "cooldown" or "cooldown:ticksRemaining" (the latter
+    // only present for a manticore mid-way through its 3-orb volley).
+    const entries = cdPart.slice(3).split(",");
+    for (var i = 0; i < mobs.length && i < entries.length; i++) {
+      const [cooldown, ticksRemaining] = entries[i].split(":").map(Number);
+      mobs[i][5] = cooldown;
+      if (!isNaN(ticksRemaining)) {
+        mobTicksRemaining[i] = ticksRemaining;
+      }
     }
   }
 
@@ -195,7 +203,8 @@ export function decodeURL(location: URL): DecodeURLResult {
     isFromWaveStart,
     isMantiMayhem3,
     playerCoordinates,
-    isReplay
+    isReplay,
+    mobTicksRemaining
   }
 }
 
@@ -230,7 +239,7 @@ function decodeCoordinates(coords: number): Coordinates {
 }
 
 export function getReplayURL(replayData: ReplayData, fromWaveStart: boolean = false, mantimayhem3: boolean = false) {
-  const { playerPositions, mobSpecs, mobCooldowns } = replayData
+  const { playerPositions, mobSpecs, mobCooldowns, mobTicksRemaining } = replayData
   var url = getSpawnUrl(mobSpecs);
   url = url.concat("#");
   var playerLocations = playerPositions.map(encodeCoordinate);
@@ -260,8 +269,13 @@ export function getReplayURL(replayData: ReplayData, fromWaveStart: boolean = fa
   if (mantimayhem3) {
     url = url.concat("_", "mm3");
   }
-  if (mobCooldowns?.some(cd => cd !== 0)) {
-    url = url.concat("_cd:", mobCooldowns.join(","));
+  if (mobCooldowns?.some(cd => cd !== 0) || mobTicksRemaining?.some(ticks => ticks !== 0)) {
+    const cooldowns = mobCooldowns ?? mobSpecs.map(() => 0);
+    const entries = cooldowns.map((cd, i) => {
+      const ticks = mobTicksRemaining?.[i] ?? 0; // manticore orb sequence only
+      return ticks !== 0 ? `${cd}:${ticks}` : `${cd}`;
+    });
+    url = url.concat("_cd:", entries.join(","));
   }
   return url;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -164,6 +164,13 @@ export function decodeURL(location: URL): DecodeURLResult {
   // Check flags
   const isFromWaveStart = hashParts?.includes("ws") || false;
   const isMantiMayhem3 = hashParts?.includes("mm3") || false;
+  const cdPart = hashParts?.find(p => p.startsWith("cd:"));
+  if (cdPart) {
+    const cooldowns = cdPart.slice(3).split(",").map(Number);
+    for (var i = 0; i < mobs.length && i < cooldowns.length; i++) {
+      mobs[i][5] = cooldowns[i];
+    }
+  }
 
   let playerCoordinates: Coordinates[] | null = null;
   let isReplay = false;
@@ -223,7 +230,7 @@ function decodeCoordinates(coords: number): Coordinates {
 }
 
 export function getReplayURL(replayData: ReplayData, fromWaveStart: boolean = false, mantimayhem3: boolean = false) {
-  const { playerPositions, mobSpecs } = replayData
+  const { playerPositions, mobSpecs, mobCooldowns } = replayData
   var url = getSpawnUrl(mobSpecs);
   url = url.concat("#");
   var playerLocations = playerPositions.map(encodeCoordinate);
@@ -252,6 +259,9 @@ export function getReplayURL(replayData: ReplayData, fromWaveStart: boolean = fa
   }
   if (mantimayhem3) {
     url = url.concat("_", "mm3");
+  }
+  if (mobCooldowns?.some(cd => cd !== 0)) {
+    url = url.concat("_cd:", mobCooldowns.join(","));
   }
   return url;
 }


### PR DESCRIPTION
***UPDATE: Now working for manticores***

## Problem
Copying a replay URL from a mid-simulation tick selection didn't preserve NPC attack cooldowns. Replayed mobs would attack on different ticks than the original simulation

## Root causes
1. No record of per-tick cooldown state
2. `getReplayData()` sourced mob positions from the wrong tick
3. `reset()` zeroed mob cooldowns on every iteration of a looping replay

## Fix
- New `cooldownTape` parallel array snapshots `mob[5]` every tick, `mirroring playerTape`
- `getReplayData()` now anchors both mobSpecs and cooldowns to the same tick
- Replay URLs gain an optional `_cd:n,n,...` hash flag, only emitted when at least one cooldown is non-zero. ***Now also encodes in-progress manticore volley state, and whether or not the manticore has seen the player***. Fully backwards compatible — old URLs without _cd decode exactly as before. Spawn URL generation (no replay/selection) is untouched
- New `initialMobCooldowns` captures decoded cooldowns once at load time, used by `reset()` instead of hardcoded 0